### PR TITLE
workaround for cpu spin when NamedPipeClientStream.Connect() is calle…

### DIFF
--- a/NamedPipeWrapper/NamedPipeWrapper.csproj
+++ b/NamedPipeWrapper/NamedPipeWrapper.csproj
@@ -45,6 +45,7 @@
     <Compile Include="IO\PipeStreamReader.cs" />
     <Compile Include="IO\PipeStreamWrapper.cs" />
     <Compile Include="IO\PipeStreamWriter.cs" />
+    <Compile Include="Native\Kernel32.cs" />
     <Compile Include="PipeExceptionEventHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NamedPipeServer.cs" />

--- a/NamedPipeWrapper/Native/Kernel32.cs
+++ b/NamedPipeWrapper/Native/Kernel32.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.InteropServices;
+
+namespace NamedPipeWrapper.Native
+{
+    internal sealed class Kernel32
+    {
+        /// <summary>
+        /// Waits until either a time-out interval elapses or an instance of the specified named pipe is available for connection
+        /// </summary>
+        /// <param name="lpNamedPipeName">The name of the named pipe. The string must include the name of the computer on which the server process is executing.</param>
+        /// <param name="nTimeOut">If no instances of the specified named pipe exist, the WaitNamedPipe function returns immediately, regardless of the time-out value.</param>
+        /// <returns></returns>
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern bool WaitNamedPipe(string lpNamedPipeName, uint nTimeOut);
+    }
+}


### PR DESCRIPTION
…d without a timeout